### PR TITLE
chore: add husky for local commit linting

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no -- commitlint --edit $1

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vs-openbinfolder",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Development dependencies for VS-OpenBinFolder - conventional commits tooling",
+  "scripts": {
+    "prepare": "husky"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^19.0.0",
+    "@commitlint/config-conventional": "^19.0.0",
+    "husky": "^9.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds package.json with minimal dev dependencies for commit linting
- Adds husky git hook configuration for local commit message validation
- Enables `npm install` to set up commitlint validation before push

## Test plan
- [ ] Run `npm install` to install dependencies and set up husky hooks
- [ ] Make a commit with an invalid message format to verify rejection
- [ ] Make a commit with valid conventional format to verify acceptance