### PR TITLE
chore: use shared changelog workflow for releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,36 +4,41 @@ on:
   workflow_dispatch:
 
 jobs:
+  changelog:
+    name: Generate Changelog
+    uses: CodingWithCalvin/.github/.github/workflows/generate-changelog.yml@main
+
   publish:
+    needs: changelog
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+
       - name: 1. Download artifact
         id: download-artifact
         uses: dawidd6/action-download-artifact@v2
         with:
-          github_token: ${{ secrets.GH_SECRET }}
           workflow: release_build_and_deploy.yml
           workflow_conclusion: success
-          
+
       - name: 2. Parse Artifact Manifest
         id: artifact_manifest
         uses: ActionsTools/read-json-action@main
         with:
           file_path: ./artifact/CodingWithCalvin.OpenBinFolder.info
-          
+
       - name: 3. Create Tag & Release
         uses: ncipollo/release-action@v1.14.0
         with:
           artifacts: ./artifact/CodingWithCalvin.OpenBinFolder.vsix
-          generateReleaseNotes: true
+          body: ${{ needs.changelog.outputs.changelog }}
           makeLatest: true
-          token: ${{ secrets.GH_SECRET }}
           commit: ${{ steps.artifact_manifest.outputs.sha }}
           tag: ${{ steps.artifact_manifest.outputs.version }}
-          
+
       - name: 4. Publish Release to Marketplace
         if: success()
         uses: CodingWithCalvin/GHA-VSMarketplacePublisher@v1
@@ -41,5 +46,3 @@ jobs:
           marketplace-pat: ${{ secrets.VS_PAT }}
           publish-manifest-path: ./resources/extension.manifest.json
           vsix-path: ./artifact/CodingWithCalvin.OpenBinFolder.vsix
-
-


### PR DESCRIPTION
## Summary
- Replaces `generateReleaseNotes: true` with the organization's shared changelog workflow
- Provides consistent, categorized release notes across all repos
- Uses `CodingWithCalvin/.github/.github/workflows/generate-changelog.yml`

## Test plan
- [ ] Verify workflow runs successfully on next release