### PR TITLE
feat(telemetry): add Otel4Vsix integration

### DIFF
--- a/src/CodingWithCalvin.OpenBinFolder/CodingWithCalvin.OpenBinFolder.csproj
+++ b/src/CodingWithCalvin.OpenBinFolder/CodingWithCalvin.OpenBinFolder.csproj
@@ -8,11 +8,8 @@
     <OutputPath>bin/$(Configuration)/</OutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <DeployExtension>True</DeployExtension>
-  </PropertyGroup>
-
   <ItemGroup>
+    <PackageReference Include="CodingWithCalvin.Otel4Vsix" Version="0.2.2" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.14.40265" />
   </ItemGroup>
 

--- a/src/CodingWithCalvin.OpenBinFolder/Commands/OpenBinFolderCommand.cs
+++ b/src/CodingWithCalvin.OpenBinFolder/Commands/OpenBinFolderCommand.cs
@@ -99,14 +99,11 @@ namespace CodingWithCalvin.OpenBinFolder.Commands
 
                 var projectBinPath = Path.Combine(projectPath, projectOutputPath);
 
-                activity?.SetTag("project.name", project.Name);
-                activity?.SetTag("project.binPath", projectBinPath);
-
-                System.Diagnostics.Process.Start(
+                                System.Diagnostics.Process.Start(
                     Directory.Exists(projectBinPath) ? projectBinPath : projectPath
                 );
 
-                VsixTelemetry.LogInformation("Opened bin folder for project {ProjectName}", project.Name);
+                VsixTelemetry.LogInformation("Opened bin folder for project");
             }
             catch (Exception ex)
             {
@@ -114,8 +111,7 @@ namespace CodingWithCalvin.OpenBinFolder.Commands
                 VsixTelemetry.TrackException(ex, new Dictionary<string, object>
                 {
                     { "operation.name", "OpenProjectBinFolder" },
-                    { "project.name", project.Name }
-                });
+                    });
 
                 MessageBox.Show(
                     $@"

--- a/src/CodingWithCalvin.OpenBinFolder/Commands/OpenBinFolderCommand.cs
+++ b/src/CodingWithCalvin.OpenBinFolder/Commands/OpenBinFolderCommand.cs
@@ -1,7 +1,9 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.IO;
 using System.Windows.Forms;
+using CodingWithCalvin.Otel4Vsix;
 using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio.Shell;
@@ -44,39 +46,48 @@ namespace CodingWithCalvin.OpenBinFolder.Commands
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            if (!(ServiceProvider.GetService(typeof(DTE)) is DTE2 dte))
-            {
-                throw new ArgumentNullException(nameof(dte));
-            }
+            using var activity = VsixTelemetry.StartCommandActivity("OpenBinFolder.OpenPath");
 
-            foreach (
-                UIHierarchyItem selectedItem in (Array)
-                    dte.ToolWindows.SolutionExplorer.SelectedItems
-            )
+            try
             {
-                switch (selectedItem.Object)
+                if (!(ServiceProvider.GetService(typeof(DTE)) is DTE2 dte))
                 {
-                    case Project project:
-                        try
-                        {
-                            OpenProjectBinFolder(project);
-                        }
-                        catch (Exception ex)
-                        {
-                            MessageBox.Show(
-                                $@"
-                                Unable to determine output path for selected project
-                                {Environment.NewLine}
-                                {Environment.NewLine}
-                                Exception: {ex.Message}"
-                            );
-                        }
-
-                        break;
+                    throw new ArgumentNullException(nameof(dte));
                 }
-            }
 
-            void OpenProjectBinFolder(Project project)
+                foreach (
+                    UIHierarchyItem selectedItem in (Array)
+                        dte.ToolWindows.SolutionExplorer.SelectedItems
+                )
+                {
+                    switch (selectedItem.Object)
+                    {
+                        case Project project:
+                            OpenProjectBinFolder(project);
+                            break;
+                    }
+                }
+
+                VsixTelemetry.LogInformation("Bin folder opened successfully");
+            }
+            catch (Exception ex)
+            {
+                activity?.RecordError(ex);
+                VsixTelemetry.TrackException(ex, new Dictionary<string, object>
+                {
+                    { "operation.name", "OpenPath" }
+                });
+                throw;
+            }
+        }
+
+        private void OpenProjectBinFolder(Project project)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            using var activity = VsixTelemetry.StartCommandActivity("OpenBinFolder.OpenProjectBinFolder");
+
+            try
             {
                 var projectPath =
                     Path.GetDirectoryName(project.FullName)
@@ -88,8 +99,30 @@ namespace CodingWithCalvin.OpenBinFolder.Commands
 
                 var projectBinPath = Path.Combine(projectPath, projectOutputPath);
 
+                activity?.SetTag("project.name", project.Name);
+                activity?.SetTag("project.binPath", projectBinPath);
+
                 System.Diagnostics.Process.Start(
                     Directory.Exists(projectBinPath) ? projectBinPath : projectPath
+                );
+
+                VsixTelemetry.LogInformation("Opened bin folder for project {ProjectName}", project.Name);
+            }
+            catch (Exception ex)
+            {
+                activity?.RecordError(ex);
+                VsixTelemetry.TrackException(ex, new Dictionary<string, object>
+                {
+                    { "operation.name", "OpenProjectBinFolder" },
+                    { "project.name", project.Name }
+                });
+
+                MessageBox.Show(
+                    $@"
+                    Unable to determine output path for selected project
+                    {Environment.NewLine}
+                    {Environment.NewLine}
+                    Exception: {ex.Message}"
                 );
             }
         }

--- a/src/CodingWithCalvin.OpenBinFolder/HoneycombConfig.cs
+++ b/src/CodingWithCalvin.OpenBinFolder/HoneycombConfig.cs
@@ -1,0 +1,7 @@
+namespace CodingWithCalvin.OpenBinFolder
+{
+    internal static class HoneycombConfig
+    {
+        public const string ApiKey = "PLACEHOLDER";
+    }
+}


### PR DESCRIPTION
## Summary
- Add CodingWithCalvin.Otel4Vsix package reference (v0.2.2)
- Configure telemetry initialization in OpenBinFolderPackage with Honeycomb export
- Add HoneycombConfig.cs for API key placeholder (CI will replace)
- Instrument OpenPath and OpenProjectBinFolder commands with activities and logging
- Add proper telemetry shutdown in Dispose
- Remove explicit DeployExtension (VsixSdk handles this automatically)

## Test plan
- [ ] Verify Debug and Release builds succeed
- [ ] Verify telemetry initializes on package load
- [ ] Verify command execution is instrumented