### PR TITLE
fix: add C++ project support for Open Bin Folder command

### DIFF
--- a/src/CodingWithCalvin.OpenBinFolder/CodingWithCalvin.OpenBinFolder.csproj
+++ b/src/CodingWithCalvin.OpenBinFolder/CodingWithCalvin.OpenBinFolder.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="CodingWithCalvin.VsixSdk/0.3.0">
+<Project Sdk="CodingWithCalvin.VsixSdk/0.4.0">
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
@@ -11,6 +11,8 @@
   <ItemGroup>
     <PackageReference Include="CodingWithCalvin.Otel4Vsix" Version="0.2.2" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.14.40265" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.*" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.VCProjectEngine" Version="17.14.40264" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CodingWithCalvin.OpenBinFolder/Commands/OpenBinFolderCommand.cs
+++ b/src/CodingWithCalvin.OpenBinFolder/Commands/OpenBinFolderCommand.cs
@@ -7,12 +7,19 @@ using CodingWithCalvin.Otel4Vsix;
 using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.VCProjectEngine;
 using Project = EnvDTE.Project;
 
 namespace CodingWithCalvin.OpenBinFolder.Commands
 {
     internal class OpenBinFolderCommand
     {
+        // Project type GUIDs
+        private const string CSharpProjectKind = "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}";
+        private const string VbNetProjectKind = "{F184B08F-C81C-45F6-A57F-5ABD9991F28F}";
+        private const string FSharpProjectKind = "{F2A71F9B-5D33-465A-A702-920D77279786}";
+        private const string CppProjectKind = "{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}";
+
         private readonly Package _package;
 
         private OpenBinFolderCommand(Package package)
@@ -93,11 +100,19 @@ namespace CodingWithCalvin.OpenBinFolder.Commands
                     Path.GetDirectoryName(project.FullName)
                     ?? throw new InvalidOperationException();
 
-                var projectOutputPath = project
-                    .ConfigurationManager.ActiveConfiguration.Properties.Item("OutputPath")
-                    .Value.ToString();
+                string projectBinPath;
 
-                var projectBinPath = Path.Combine(projectPath, projectOutputPath);
+                if (IsCppProject(project.Kind) && project.Object is VCProject vcProject)
+                {
+                    projectBinPath = GetCppOutputPath(vcProject, projectPath);
+                }
+                else
+                {
+                    var projectOutputPath = project
+                        .ConfigurationManager.ActiveConfiguration.Properties.Item("OutputPath")
+                        .Value.ToString();
+                    projectBinPath = Path.Combine(projectPath, projectOutputPath);
+                }
 
                                 System.Diagnostics.Process.Start(
                     Directory.Exists(projectBinPath) ? projectBinPath : projectPath
@@ -120,6 +135,30 @@ namespace CodingWithCalvin.OpenBinFolder.Commands
                     {Environment.NewLine}
                     Exception: {ex.Message}"
                 );
+            }
+
+            bool IsCppProject(string projectKind)
+            {
+                return string.Equals(projectKind, CppProjectKind, StringComparison.OrdinalIgnoreCase);
+            }
+
+            string GetCppOutputPath(VCProject vcProject, string projectPath)
+            {
+                var activeConfig = vcProject.ActiveConfiguration as VCConfiguration;
+                if (activeConfig == null)
+                {
+                    throw new InvalidOperationException("Unable to get active configuration for C++ project");
+                }
+
+                // Evaluate expands macros like $(OutDir), $(Configuration), $(Platform), etc.
+                var outDir = activeConfig.Evaluate("$(OutDir)");
+
+                if (Path.IsPathRooted(outDir))
+                {
+                    return outDir;
+                }
+
+                return Path.Combine(projectPath, outDir);
             }
         }
     }

--- a/src/CodingWithCalvin.OpenBinFolder/Properties/launchSettings.json
+++ b/src/CodingWithCalvin.OpenBinFolder/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "Debug Extension": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\Common7\\IDE\\devenv.exe",
+      "commandLineArgs": "/rootSuffix Exp"
+    }
+  }
+}


### PR DESCRIPTION
- Add Microsoft.VisualStudio.VCProjectEngine package reference
- Detect C++ projects using Project.Kind GUID
- Use VCProject/VCConfiguration APIs to get output directory
- Use Evaluate("$(OutDir)") to properly expand MSBuild macros

Fixes #4