### PR TITLE
test(manifest): repo field only (no MoreInfo)

### DIFF
--- a/resources/extension.manifest.json
+++ b/resources/extension.manifest.json
@@ -11,5 +11,5 @@
   "overview": "../README.md",
   "publisher": "CodingWithCalvin",
   "qna": false,
-  "repo": "https://www.github.com/CodingWithCalvin/VS-OpenBinFolder"
+  "repo": "https://github.com/CodingWithCalvin/VS-OpenBinFolder"
 }

--- a/src/CodingWithCalvin.OpenBinFolder/source.extension.vsixmanifest
+++ b/src/CodingWithCalvin.OpenBinFolder/source.extension.vsixmanifest
@@ -4,7 +4,6 @@
         <Identity Id="VS-OpenBinFolder" Version="1.1" Language="en-US" Publisher="Coding With Calvin" />
         <DisplayName>Open Bin Folder</DisplayName>
         <Description xml:space="preserve">Adds an 'Open Bin Folder' to the right click menu of the project for quick access to the builds output folder.</Description>
-        <MoreInfo>https://github.com/CodingWithCalvin/VS-OpenBinFolder</MoreInfo>
         <License>resources\LICENSE</License>
         <Icon>resources\logo.png</Icon>
         <Tags>bin,debug,folder,output</Tags>


### PR DESCRIPTION
## Test A

Testing if `repo` field in extension.manifest.json alone is sufficient for marketplace link.

| File | Change |
|------|--------|
| extension.manifest.json | `www.github.com` → `github.com` |
| source.extension.vsixmanifest | Removed `<MoreInfo>` element |