### PR TITLE
fix(vsix): include VCProjectEngine assembly in VSIX package

### DIFF
--- a/src/CodingWithCalvin.OpenBinFolder/CodingWithCalvin.OpenBinFolder.csproj
+++ b/src/CodingWithCalvin.OpenBinFolder/CodingWithCalvin.OpenBinFolder.csproj
@@ -12,7 +12,9 @@
     <PackageReference Include="CodingWithCalvin.Otel4Vsix" Version="0.2.2" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.14.40265" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.*" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.VCProjectEngine" Version="17.14.40264" />
+    <PackageReference Include="Microsoft.VisualStudio.VCProjectEngine" Version="17.14.40264">
+      <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- VSSDK.BuildTools has a hardcoded `SuppressFromVsix` list that excludes `Microsoft.VisualStudio.VCProjectEngine.dll`, assuming Visual Studio always provides it
- Users without the C++ workload installed hit a missing assembly error when using the extension
- Added `ForceIncludeInVSIX` metadata to the package reference to override the suppression and ship the assembly with the VSIX

## Test plan
- [ ] Build the project and verify `Microsoft.VisualStudio.VCProjectEngine.dll` is present in the VSIX
- [ ] Install the VSIX in a VS instance without the C++ workload and verify "Open Bin Folder" works on C# projects
- [ ] Test "Open Bin Folder" on a C++ project with the C++ workload installed

Fixes #32