### PR TITLE
fix(vcproject): use dynamic binding to avoid assembly load failure

### DIFF
--- a/src/CodingWithCalvin.OpenBinFolder/CodingWithCalvin.OpenBinFolder.csproj
+++ b/src/CodingWithCalvin.OpenBinFolder/CodingWithCalvin.OpenBinFolder.csproj
@@ -12,9 +12,7 @@
     <PackageReference Include="CodingWithCalvin.Otel4Vsix" Version="0.2.2" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.14.40265" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.*" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.VCProjectEngine" Version="17.14.40264">
-      <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
-    </PackageReference>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CodingWithCalvin.OpenBinFolder/Commands/OpenBinFolderCommand.cs
+++ b/src/CodingWithCalvin.OpenBinFolder/Commands/OpenBinFolderCommand.cs
@@ -7,7 +7,6 @@ using CodingWithCalvin.Otel4Vsix;
 using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.VCProjectEngine;
 using Project = EnvDTE.Project;
 
 namespace CodingWithCalvin.OpenBinFolder.Commands
@@ -102,9 +101,9 @@ namespace CodingWithCalvin.OpenBinFolder.Commands
 
                 string projectBinPath;
 
-                if (IsCppProject(project.Kind) && project.Object is VCProject vcProject)
+                if (IsCppProject(project.Kind))
                 {
-                    projectBinPath = GetCppOutputPath(vcProject, projectPath);
+                    projectBinPath = GetCppOutputPath(project.Object, projectPath);
                 }
                 else
                 {
@@ -142,16 +141,16 @@ namespace CodingWithCalvin.OpenBinFolder.Commands
                 return string.Equals(projectKind, CppProjectKind, StringComparison.OrdinalIgnoreCase);
             }
 
-            string GetCppOutputPath(VCProject vcProject, string projectPath)
+            string GetCppOutputPath(dynamic vcProject, string projectPath)
             {
-                var activeConfig = vcProject.ActiveConfiguration as VCConfiguration;
+                dynamic activeConfig = vcProject.ActiveConfiguration;
                 if (activeConfig == null)
                 {
                     throw new InvalidOperationException("Unable to get active configuration for C++ project");
                 }
 
                 // Evaluate expands macros like $(OutDir), $(Configuration), $(Platform), etc.
-                var outDir = activeConfig.Evaluate("$(OutDir)");
+                string outDir = activeConfig.Evaluate("$(OutDir)");
 
                 if (Path.IsPathRooted(outDir))
                 {


### PR DESCRIPTION
## Summary
- Removes compile-time reference to `Microsoft.VisualStudio.VCProjectEngine` and replaces it with `dynamic` late binding
- The previous fix (#33) bundled the assembly in the VSIX, but users still reported the same `FileNotFoundException` on both VS 2022 and VS 2026
- By using `dynamic`, the VCProjectEngine assembly is only resolved at runtime when actually handling a C++ project, preventing the error for all other project types

## Root Cause
The JIT compiler needed to resolve `VCProject` and `VCConfiguration` types when compiling `OpenProjectBinFolder`, even for non-C++ projects. This caused an assembly load failure for users without the C++ workload installed, regardless of whether the assembly was bundled in the VSIX.

## Test plan
- [ ] Open a C#/VB.NET/F# project in VS 2022 and use "Open Bin Folder" — should work without errors
- [ ] Open a C++ project in VS 2022 (with C++ workload) and use "Open Bin Folder" — should work correctly
- [ ] Verify on VS 2026

Resolves #32