### PR TITLE
ci(workflow): remove social media inputs from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,5 +14,4 @@ jobs:
       extension-name: OpenBinFolder
       display-name: 'Open Bin Folder'
       marketplace-id: CodingWithCalvin.VS-OpenBinFolder
-      description: 'Quick access to the builds output folder from the project context menu'
     secrets: inherit


### PR DESCRIPTION
## Summary
- Remove social media inputs (`description`, `hashtags`) from publish workflow that are no longer used by the reusable vsix-publish workflow

## Test plan
- [ ] Verify publish workflow still works correctly